### PR TITLE
fix(s3): legacy respeta S3_ENDPOINT_URL si está definida

### DIFF
--- a/services/s3_toolkit.py
+++ b/services/s3_toolkit.py
@@ -26,18 +26,24 @@ def upload_to_s3(file_path, s3_url, access_key, secret_key):
     bucket_name, region, endpoint_url = parse_s3_url(s3_url)
 
     signature_version = os.getenv('S3_SIGNATURE_VERSION')
+    addressing_style = os.getenv('S3_ADDRESSING_STYLE')
+    config_kwargs = {}
     if signature_version:
-        boto_config = Config(signature_version=signature_version)
-    else:
-        boto_config = Config()
+        config_kwargs['signature_version'] = signature_version
+    if addressing_style:
+        config_kwargs['s3'] = {'addressing_style': addressing_style}
 
     session = boto3.Session(
         aws_access_key_id=access_key,
         aws_secret_access_key=secret_key,
         region_name=region
     )
-    
-    client = session.client('s3', endpoint_url=endpoint_url, config=boto_config)
+
+    if config_kwargs:
+        boto_config = Config(**config_kwargs)
+        client = session.client('s3', endpoint_url=endpoint_url, config=boto_config)
+    else:
+        client = session.client('s3', endpoint_url=endpoint_url)
 
     try:
         # Upload the file to the specified S3 bucket

--- a/services/s3_toolkit.py
+++ b/services/s3_toolkit.py
@@ -2,6 +2,7 @@ import os
 import boto3
 import logging
 from urllib.parse import urlparse
+from botocore.config import Config
 
 logger = logging.getLogger(__name__)
 
@@ -23,14 +24,20 @@ def parse_s3_url(s3_url):
 def upload_to_s3(file_path, s3_url, access_key, secret_key):
     # Parse the S3 URL into bucket, region, and endpoint
     bucket_name, region, endpoint_url = parse_s3_url(s3_url)
-    
+
+    signature_version = os.getenv('S3_SIGNATURE_VERSION')
+    if signature_version:
+        boto_config = Config(signature_version=signature_version)
+    else:
+        boto_config = Config()
+
     session = boto3.Session(
         aws_access_key_id=access_key,
         aws_secret_access_key=secret_key,
         region_name=region
     )
     
-    client = session.client('s3', endpoint_url=endpoint_url)
+    client = session.client('s3', endpoint_url=endpoint_url, config=boto_config)
 
     try:
         # Upload the file to the specified S3 bucket

--- a/services/s3_toolkit.py
+++ b/services/s3_toolkit.py
@@ -15,8 +15,8 @@ def parse_s3_url(s3_url):
     # Extract region from the host
     region = parsed_url.hostname.split('.')[1]
     
-    # Construct endpoint URL
-    endpoint_url = f"https://{region}.digitaloceanspaces.com"
+    # Use endpoint from env if defined, else fallback to DO Spaces
+    endpoint_url = os.getenv('S3_ENDPOINT_URL') or f"https://{region}.digitaloceanspaces.com"
     
     return bucket_name, region, endpoint_url
 

--- a/services/s3_toolkit.py
+++ b/services/s3_toolkit.py
@@ -2,7 +2,6 @@ import os
 import boto3
 import logging
 from urllib.parse import urlparse
-from botocore.config import Config
 
 logger = logging.getLogger(__name__)
 
@@ -24,26 +23,14 @@ def parse_s3_url(s3_url):
 def upload_to_s3(file_path, s3_url, access_key, secret_key):
     # Parse the S3 URL into bucket, region, and endpoint
     bucket_name, region, endpoint_url = parse_s3_url(s3_url)
-
-    signature_version = os.getenv('S3_SIGNATURE_VERSION')
-    addressing_style = os.getenv('S3_ADDRESSING_STYLE')
-    config_kwargs = {}
-    if signature_version:
-        config_kwargs['signature_version'] = signature_version
-    if addressing_style:
-        config_kwargs['s3'] = {'addressing_style': addressing_style}
-
+    
     session = boto3.Session(
         aws_access_key_id=access_key,
         aws_secret_access_key=secret_key,
         region_name=region
     )
-
-    if config_kwargs:
-        boto_config = Config(**config_kwargs)
-        client = session.client('s3', endpoint_url=endpoint_url, config=boto_config)
-    else:
-        client = session.client('s3', endpoint_url=endpoint_url)
+    
+    client = session.client('s3', endpoint_url=endpoint_url)
 
     try:
         # Upload the file to the specified S3 bucket

--- a/services/s3_toolkit.py
+++ b/services/s3_toolkit.py
@@ -12,11 +12,16 @@ def parse_s3_url(s3_url):
     # Extract bucket name from the host
     bucket_name = parsed_url.hostname.split('.')[0]
     
-    # Extract region from the host
-    region = parsed_url.hostname.split('.')[1]
+    # Use S3_REGION env var if defined, else extract from host, else None
+    region = os.getenv('S3_REGION')
+    if not region:
+        host_parts = parsed_url.hostname.split('.') if parsed_url.hostname else []
+        region = host_parts[1] if len(host_parts) > 1 else None
     
     # Use endpoint from env if defined, else fallback to DO Spaces
-    endpoint_url = os.getenv('S3_ENDPOINT_URL') or f"https://{region}.digitaloceanspaces.com"
+    endpoint_url = os.getenv('S3_ENDPOINT_URL')
+    if not endpoint_url and region:
+        endpoint_url = f"https://{region}.digitaloceanspaces.com"
     
     return bucket_name, region, endpoint_url
 


### PR DESCRIPTION
Este PR soluciona el vendor lock-in de DigitalOcean Spaces en el toolkit S3.

- Si S3_ENDPOINT_URL está definida, se usa como endpoint para el cliente S3.
- Si no está definida, se sigue usando el endpoint de DigitalOcean Spaces según la región (comportamiento anterior).
- No se requieren nuevas variables ni cambios en la firma de funciones.
- Retrocompatible: los usuarios actuales no tienen que modificar nada.

Esto permite usar MinIO, R2, Supabase, etc. sin romper la compatibilidad con los entornos existentes.